### PR TITLE
Add <meta charset='utf-8'> to layouts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset='utf-8'>        
 		<title>{{page.title}} - Brat Programming Language</title>
 		<link href="/style/main.css" media="all" rel="stylesheet" type="text/css" />
 	</head>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 	<head>
+		<meta charset='utf-8'>        
 		<title>Brat Programming Language Documentation - {{page.object}}</title>
 		<link href="/style/main.css" media="all" rel="stylesheet" type="text/css" />
 		<link href="/style/doc.css" media="all" rel="stylesheet" type="text/css" />

--- a/_layouts/lib.html
+++ b/_layouts/lib.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 	<head>
+		<meta charset='utf-8'>        
 		<title>Brat Programming Language Documentation - {{page.lib}}</title>
 		<link href="/style/main.css" media="all" rel="stylesheet" type="text/css" />
 		<link href="/style/doc.css" media="all" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Hi,

brat-lang.org looks strange in my browser:
![](http://gyazo.com/6c1fb97a7c6858250306a2202100ac43.png)

I'm not sure what tool you're using to build the site, but this pull request should fix it.
