### PR TITLE
Fix for rex_onig 2.6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ make
 cp -f src/oniguruma/rex_onig.so.2.6 $LIB
 #cp -f src/onigurum/librex_onig.a $LIB
 cd $LIB
-ln -s -f rex_onig.so.2.4 rex_onig.so
+ln -s -f rex_onig.so.2.6 rex_onig.so
 
 echo Building luafilesystem
 cd $SRC/luafilesystem

--- a/core/core.lua
+++ b/core/core.lua
@@ -85,9 +85,7 @@ end
 
 --Functions for identifier conversion
 
-require "rex_onig"
-local orex = rex_onig
-rex_onig = nil
+local orex = require "rex_onig"
 
 local escape_ops = { ["!"] = "_bang",
 ["*"] = "_star",


### PR DESCRIPTION
@presidentbeef 

6 days ago, you updated rex_onig version, but you missed update `ln` location. `build.sh` is now broken. (I guess, your development directory still remains old symbolic link to `rex_onig.so.2.4`. It works on your PC, but actually using rex_onig version is not updated.)

I fixed it and changes following rex_onig update.