### PR TITLE
Add lua to PATH to build without installing Lua

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,7 @@ STDLIB=$BRATPATH/stdlib
 export LUA_SRC_PATH=$BRATPATH/bin/lua/
 export LUA_INC_PATH=$BRATPATH/bin/lua/include/luajit-2.1
 export BRAT_LIB_PATH=$LIB
+export PATH=$LUA_SRC_PATH/bin:$PATH
 
 cd $SRC
 


### PR DESCRIPTION
To build some Lua library needs lua command.