### PR TITLE
[core] Fix rescue when throwing Brat string

### DIFF
--- a/core/core.lua
+++ b/core/core.lua
@@ -1253,7 +1253,7 @@ function object:protect (block, options)
 
     if rescue then
       handler = function(err)
-        if type(err) ~= "table" then
+        if type(err) ~= "table" or err._lua_string then
           err = exception:new(tostring(err))
         end
 

--- a/test/test-misc.brat
+++ b/test/test-misc.brat
@@ -155,7 +155,7 @@ add_results setup name: "miscellaneous tests" {
   }
 
   test "rescue" {
-    assert_equal "eep" { protect { throw 'eep' } rescue: { e | e } }
+    assert_equal "eep" { protect { throw 'eep' } rescue: { e | e.error_message } }
     assert_equal "hello" { protect { throw 'eep' } rescue: { 'hello' } }
   }
 


### PR DESCRIPTION
As a result, you can now see the (consistently) failing AST tests from the earlier re-introduction of symbols.