### PR TITLE
Improve PEG performance

### DIFF
--- a/stdlib/peg.brat
+++ b/stdlib/peg.brat
@@ -15,30 +15,23 @@ peg = object.new
 
 peg.init = { gramma = null |
   my.named_rules = [:]
-  my.rule_names = [:]
   my.first = null
   my.rule_id = 0
-  my.memo = [:]
+  my.memo = []
 
   gramma #Actually set up parser
 }
 
-peg.prototype.next_id = {
-  my.rule_id = my.rule_id + 1
-}
-
-memo_rule = { x |
+memo_rule = { x, rule, memo |
   m = memo[x.pos]
 
   null? m
   {
     current = x.pos
     res = rule x
+
     true? res
     {
-      null? res.rule_name
-        { res.rule_name = rules[->real] }
-
       memo[current] = [res, x.pos]
     }
     {
@@ -57,14 +50,10 @@ memo_rule = { x |
 }
 
 peg.prototype.make_rule = { rule |
-  r = object.new
-  r.memo = [:]
-  memo[next_id] = r.memo
-  r.rule = ->rule
-  r.rules = my.rule_names
-  r.memo_rule = ->memo_rule
+  rule_memo = [:]
+  memo << rule_memo
 
-  r.real = { x | r.memo_rule x }
+  { x | memo_rule x, ->rule, rule_memo }
 }
 
 peg.make_result = { match_pos, end_pos, matched, rule_name = null |
@@ -96,7 +85,7 @@ peg.prototype.parse = { str, start_rule = null, fully = false |
   null? start_rule
     { start_rule = my.first }
 
-  my.memo.each_value { v | v.clear }
+  my.memo.each { v | v.clear }
 
   s = scanner.new str
   rule = my.named_rules[start_rule]
@@ -311,13 +300,25 @@ peg.prototype.and = { rule |
   make_rule { x | and_matcher x, ->rule }
 }
 
+set_namer = { x, rule, name |
+  res = rule x
+
+  true? res
+  {
+    res.rule_name = name
+  }
+
+  res
+}
+
 #Set a named rule
 peg.prototype.set = { name, rule |
   null? my.first
     { my.first = name }
 
-  my.rule_names[->rule] = name
-  my.named_rules[name] = ->rule
+
+  r = make_rule { x | set_namer x, ->rule, name }
+  my.named_rules[name] = ->r
 }
 
 anything_matcher = { x |

--- a/stdlib/peg.brat
+++ b/stdlib/peg.brat
@@ -27,33 +27,31 @@ peg.prototype.next_id = {
   my.rule_id = my.rule_id + 1
 }
 
-peg.make_memo = { result, pos |
-  true? result
-    {
-      m = object.new
-      m.result = result
-      m.pos = pos
-      m
-    }
-}
-
 memo_rule = { x |
   m = memo[x.pos]
+
   null? m
   {
     current = x.pos
     res = rule x
-    memo[current] = peg.make_memo res, x.pos
-    true? res && { null? res.rule_name }
-      { res.rule_name = rules[->real] }
+    true? res
+    {
+      null? res.rule_name
+        { res.rule_name = rules[->real] }
+
+      memo[current] = [res, x.pos]
+    }
+    {
+      memo[current] = false
+    }
 
     res
   }
   {
     true? m
     {
-      x.pos = m.pos
-        m.result
+      x.pos = m[1]
+      m[0]
     }
   }
 }


### PR DESCRIPTION
* Fix how rule names are tracked/applied (no need for hash table)
* Simplify rule-level match caching (arrays instead of hashes, inlined code)
* Simplify parse-level match caching (array instead of hash) (note this is only needed to clear rule caches when re-using parser)
* Above changes removed need for complicated rule closure and object creation for each rule

### Performance

Times below are in seconds. Only parse time is included. Average of 10 runs.

File | Before | After | Change
-----|-----------|--------|-----------
peg.brat (7.8kb) | 3.009703 | 2.351904 | -22%
invoke_helper.brat (15kb) | 3.570489 | 2.696362 | -24%
parser.brat (14kb) | 5.05334 | 3.235386 | -36%
life.brat (1.1kb) | 0.803088 | 0.312095 | -61%